### PR TITLE
Add relaxation aid webpage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Open MoCap Biomech
+
+This repository contains experimental web pages for motion capture and related utilities.
+
+## Relaxation Aid
+
+`relaxation_aid.html` is a simple tool that loops a short video while playing a calming audio track for one hour. Place a six‑second video named `loop.mp4` and a music file named `relaxing.mp3` in the same directory, then open the HTML file in your browser.
+
+The page automatically plays both files on a loop and displays a countdown timer. After one hour, playback stops.

--- a/relaxation_aid.html
+++ b/relaxation_aid.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Relaxing Focus Aid</title>
+  <style>
+    body {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      height: 100vh;
+      margin: 0;
+      background: #000;
+      color: #fff;
+      font-family: Arial, sans-serif;
+    }
+    video {
+      max-width: 100%;
+      border-radius: 8px;
+    }
+    audio {
+      display: none;
+    }
+    #timer {
+      margin-top: 15px;
+      font-size: 1.2em;
+    }
+  </style>
+</head>
+<body>
+  <video id="relaxVideo" src="loop.mp4" loop muted></video>
+  <audio id="relaxAudio" src="relaxing.mp3" loop></audio>
+  <p id="timer">Remaining Time: 60:00</p>
+
+  <script>
+    const video = document.getElementById('relaxVideo');
+    const audio = document.getElementById('relaxAudio');
+    const timerDisplay = document.getElementById('timer');
+    let remaining = 3600; // one hour in seconds
+
+    // Start playback when media is ready
+    video.addEventListener('canplay', () => { video.play(); });
+    audio.addEventListener('canplay', () => { audio.play(); });
+
+    // Update the countdown every second
+    const interval = setInterval(() => {
+      remaining--;
+      const minutes = String(Math.floor(remaining / 60)).padStart(2, '0');
+      const seconds = String(remaining % 60).padStart(2, '0');
+      timerDisplay.textContent = `Remaining Time: ${minutes}:${seconds}`;
+
+      if (remaining <= 0) {
+        clearInterval(interval);
+        video.pause();
+        audio.pause();
+        timerDisplay.textContent = 'Session Complete';
+      }
+    }, 1000);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `relaxation_aid.html` for looping a 6‑second video with a calming song and a timer that stops after one hour
- document how to use the new relaxation aid in `README.md`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68448fa0d5c08332868a9f6e5a43ab2e